### PR TITLE
Fix gyro for field oriented drive

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -83,7 +83,7 @@ public class RobotContainer {
     NamedCommands.registerCommand("Third Shoot", thirdShoot);
     NamedCommands.registerCommand("Close First", closeShoot);
 
-    autoChooser = AutoBuilder.buildAutoChooser("");
+    //autoChooser = AutoBuilder.buildAutoChooser("");
   }
 
   /**
@@ -115,7 +115,7 @@ public class RobotContainer {
         .applyRequest(() -> point.withModuleDirection(new Rotation2d(-driverController.getLeftY(), -driverController.getLeftX()))));
 
     // reset the field-centric heading on start button press
-    driverController.start().onTrue(drivetrain.runOnce(() -> drivetrain.seedFieldRelative()));
+    driverController.start().onTrue(drivetrain.runOnce(() -> drivetrain.zeroGyro()));
 
 
     if (Utils.isSimulation()) {

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -17,6 +17,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Notifier;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import frc.lib.util.FieldUtil;
@@ -57,6 +58,12 @@ public class SwerveSubsystem extends SwerveDrivetrain implements Subsystem {
             SwerveModule module = Modules[i];
             TalonFX.optimizeBusUtilizationForAll(module.getDriveMotor(), module.getSteerMotor());
         }
+    }
+
+    @Override
+    public void periodic() {
+        Pose2d pose = m_odometry.getEstimatedPosition();
+        SmartDashboard.putNumberArray("pose estimation", new Double[] {pose.getX(), pose.getY(), pose.getRotation().getDegrees()});
     }
 
     public void zeroGyro() {

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -59,6 +59,10 @@ public class SwerveSubsystem extends SwerveDrivetrain implements Subsystem {
         }
     }
 
+    public void zeroGyro() {
+        m_pigeon2.setYaw(0);
+    }
+
     private void startSimThread() {
         lastSimTime = Utils.getCurrentTimeSeconds();
 


### PR DESCRIPTION
field oriented drive had problems with resetting the gyro and heading.
replace seedfieldrelative with just a zerogyro.