### PR TITLE
fix stopmotors method to swiftly stop shooter motors

### DIFF
--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -21,6 +21,7 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.AbsoluteSensorRangeValue;
 import com.ctre.phoenix6.signals.FeedbackSensorSourceValue;
 import com.ctre.phoenix6.signals.InvertedValue;
+import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.SensorDirectionValue;
 
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -96,6 +97,8 @@ public class Shooter extends SubsystemBase {
     armPositionEncoder.getAbsolutePosition().setUpdateFrequency(200);
     leftShootMotor.getVelocity().setUpdateFrequency(50);
     rightShootMotor.getVelocity().setUpdateFrequency(50);
+    leftShootMotor.setNeutralMode(NeutralModeValue.Brake);
+    rightShootMotor.setNeutralMode(NeutralModeValue.Brake);
 //    TalonFX.optimizeBusUtilizationForAll(pivotMotor, leftShootMotor, rightShootMotor);
     stopMotors();
     setAngle(targetArmPosition);


### PR DESCRIPTION
when intaking a note right after shooting, the shooters will still be moving causing the not to fly outat slow speeds