### PR TITLE
make additional sequencial intake Command for use in auto

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -28,6 +28,9 @@ import frc.robot.commands.PrepCommandForAuto;
 import frc.robot.commands.ShootCommand;
 import frc.robot.commands.calibration.CalibrateWristAngleCommand;
 import frc.robot.commands.intake.EjectCommand;
+import frc.robot.commands.intake.Auto.MoveBack;
+import frc.robot.commands.intake.Auto.NoteInShooter;
+import frc.robot.commands.intake.Auto.StartIntake;
 import frc.robot.generated.SwerveTunerConstants;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Shooter;
@@ -61,6 +64,11 @@ public class RobotContainer {
     private final EjectCommand ejectCommand = new EjectCommand(intakeSubsystem);
 
     private final PrepCommandForAuto autoSpeakerPrep = new PrepCommandForAuto(shooterSubsystem, 67, 80);
+
+
+    private final Command intakeCommand = new StartIntake(intakeSubsystem, shooterSubsystem)
+            .andThen(new NoteInShooter(intakeSubsystem, shooterSubsystem)
+            .andThen(new MoveBack(intakeSubsystem, shooterSubsystem)));
 
     public final CommandXboxController driverController =
             new CommandXboxController(OperatorConstants.kDriverControllerPort);
@@ -96,7 +104,7 @@ public class RobotContainer {
         NamedCommands.registerCommand("Shoot", shootCommand);
         NamedCommands.registerCommand("Stage Speaker Shoot", stageSpeakerShoot);
         NamedCommands.registerCommand("Trap Shoot", trapShoot);
-        NamedCommands.registerCommand("Intake", commands.intakeNoteAndKeepRunningCommand());
+        NamedCommands.registerCommand("Intake", intakeCommand);
 
         // TODO: tune positions of robot especially with bumpers
         autoChooser = AutoBuilder.buildAutoChooser("");

--- a/src/main/java/frc/robot/commands/intake/Auto/MoveBack.java
+++ b/src/main/java/frc/robot/commands/intake/Auto/MoveBack.java
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.intake.Auto;
+
+import com.ctre.phoenix6.controls.NeutralOut;
+import com.ctre.phoenix6.controls.VoltageOut;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Shooter;
+
+public class MoveBack extends Command {
+    private final Intake intake;
+    private final Shooter shooter;
+
+    private final Timer timer = new Timer();
+
+    private final VoltageOut voltageOut = new VoltageOut(0.0);
+    private final NeutralOut brake = new NeutralOut();
+
+    public MoveBack(Intake intake, Shooter shooter) {
+        this.intake = intake;
+        this.shooter = shooter;
+        addRequirements(intake);
+    }
+
+    @Override
+    public void initialize() {
+        timer.restart();
+        intake.setMotorControl(voltageOut.withOutput(-1.2)); // Move the note back slightly
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        intake.setMotorControl(brake);
+        shooter.setNoteInShooter(true);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return timer.hasElapsed(0.15);
+    }
+}

--- a/src/main/java/frc/robot/commands/intake/Auto/NoteInShooter.java
+++ b/src/main/java/frc/robot/commands/intake/Auto/NoteInShooter.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.intake.Auto;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Shooter;
+
+public class NoteInShooter extends Command {
+    Intake intake;
+    Shooter shooter;
+
+    /** Creates a new StartIntake. */
+    public NoteInShooter(Intake intake, Shooter shooter) {
+        this.intake = intake;
+        addRequirements(intake);
+        // Use addRequirements() here to declare subsystem dependencies.
+    }
+
+    // Called when the command is initially scheduled.
+    @Override
+    public void initialize() {
+        shooter.readyArmForNewNote();
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        boolean noteAtShooterSensor = intake.noteAtShooterSensor();
+        return !noteAtShooterSensor;
+    }
+}

--- a/src/main/java/frc/robot/commands/intake/Auto/StartIntake.java
+++ b/src/main/java/frc/robot/commands/intake/Auto/StartIntake.java
@@ -1,0 +1,51 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.intake.Auto;
+
+import com.ctre.phoenix6.controls.VoltageOut;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Shooter;
+
+public class StartIntake extends Command {
+    private final VoltageOut voltageOut = new VoltageOut(0.0);
+    Intake intake;
+    Shooter shooter;
+
+    /** Creates a new StartIntake. */
+    public StartIntake(Intake intake, Shooter shooter) {
+        this.intake = intake;
+        addRequirements(intake);
+        // Use addRequirements() here to declare subsystem dependencies.
+    }
+
+    // Called when the command is initially scheduled.
+    @Override
+    public void initialize() {
+        shooter.readyArmForNewNote();
+    }
+
+    // Called every time the scheduler runs while the command is scheduled.
+    @Override
+    public void execute() {
+        intake.setMotorControl(voltageOut.withOutput(4)); // Chosen by fair dice roll
+    }
+
+    // Called once the command ends or is interrupted.
+    @Override
+    public void end(boolean interrupted) {
+    }
+
+    // Returns true when the command should end.
+    @Override
+    public boolean isFinished() {
+        boolean noteAtPreIntakeSensor = intake.noteAtPreIntakeSensor();
+        boolean noteAtIntakeSensor = intake.noteAtIntakeSensor();
+        boolean noteAtShooterSensor = intake.noteAtShooterSensor();
+        boolean noteAtAnySensor = noteAtPreIntakeSensor || noteAtIntakeSensor || noteAtShooterSensor;
+        return noteAtAnySensor;
+    }
+}


### PR DESCRIPTION
currently, the intake group of commands used in teleop is unable to be used for auto as the command never ends and stops the execution of the next command/path in pathplanner.  